### PR TITLE
Potential fix for code scanning alert no. 36: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -172,7 +172,7 @@ const postResetPassword = async (req, res) => {
             return res.status(400).json({ message: 'Email required' });
         }
 
-        const user = await User.findOne({ email });
+        const user = await User.findOne({ email: { $eq: email } });
 
         if (!user) {
             return res.status(400).json({ message: 'Email is not associated with a user' });


### PR DESCRIPTION
Potential fix for [https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/36](https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/36)

To fix the problem, we need to ensure that the user-provided `email` value is safely embedded into the MongoDB query. We can achieve this by using the `$eq` operator to ensure that the `email` is treated as a literal value. This approach prevents any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
