### PR TITLE
Potential fix for code scanning alert no. 30: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "mongoose": "^8.9.4",
     "path": "^0.12.7",
     "resend": "^4.0.1",
-    "validator": "^13.12.0"
+    "validator": "^13.12.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const mongoose = require('mongoose');
 const cookieParser = require('cookie-parser');
+const lusca = require('lusca');
 const { router: indexRoutes } = require('./routes/indexRoutes.js');
 const { router: dashboardRoutes } = require('./routes/dashboardRoutes.js');
 const { router: authRoutes } = require('./routes/authRoutes.js');
@@ -16,6 +17,7 @@ app.use(express.static('public'));
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
+app.use(lusca.csrf());
 
 // Use each router separately
 app.use('/', indexRoutes);


### PR DESCRIPTION
Potential fix for [https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/30](https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/30)

To fix the problem, we need to add CSRF protection middleware to the Express application. The recommended middleware for this purpose is `lusca.csrf`. We will need to install the `lusca` package and then use it in the application to protect against CSRF attacks.

1. Install the `lusca` package.
2. Import the `lusca` package in the `src/app.js` file.
3. Add the `lusca.csrf()` middleware to the Express application before defining the routes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
