### PR TITLE
Potential fix for code scanning alert no. 41: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -507,7 +507,7 @@ const postChangeEmail = async (req, res) => {
             return res.render("error.ejs", { errorMessage: 'Email already exists' });
         }
 
-        const user = await User.findOne({ email: currentEmail });
+        const user = await User.findOne({ email: { $eq: currentEmail } });
 
         if (!user.email === currentEmail) {
             return res.render("error.ejs", { errorMessage: 'Not authorized' });


### PR DESCRIPTION
Potential fix for [https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/41](https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/41)

To fix the problem, we need to ensure that the `currentEmail` value is sanitized before being used in the MongoDB query. We can use the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
