### PR TITLE
Potential fix for code scanning alert no. 40: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -502,7 +502,7 @@ const postChangeEmail = async (req, res) => {
             return res.render("error.ejs", { errorMessage: 'New email must be different from current email' });
         }
 
-        const existingEmail = await User.findOne({ email: newEmail });
+        const existingEmail = await User.findOne({ email: { $eq: newEmail } });
         if (existingEmail) {
             return res.render("error.ejs", { errorMessage: 'Email already exists' });
         }


### PR DESCRIPTION
Potential fix for [https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/40](https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/40)

To fix the problem, we need to ensure that the `newEmail` value is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator in the query. This operator ensures that the value is interpreted as a literal value and not as a query object.

We will modify the query on line 505 to use the `$eq` operator for the `newEmail` value. This change will ensure that the user input is safely embedded into the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
