### PR TITLE
Potential fix for code scanning alert no. 43: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/dashboardController.js
+++ b/src/controllers/dashboardController.js
@@ -146,7 +146,7 @@ const editSshKeyDashboard = async (req, res) => {
             return res.render("error.ejs", { errorMessage: 'SSH key is too long. Maximum size is 16KB' });
         }
 
-        const sshKey = await ShhKey.findOne({ username, title });
+        const sshKey = await ShhKey.findOne({ username, title: { $eq: title } });
 
         if (!sshKey) {
             return res.render("error.ejs", { errorMessage: 'SSH key not found' });


### PR DESCRIPTION
Potential fix for [https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/43](https://github.com/chrwiencke/Shhhhhkeys/security/code-scanning/43)

To fix the problem, we need to ensure that the `title` parameter is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. This change will be made in the `editSshKeyDashboard` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
